### PR TITLE
Remove error prone @class decorator.

### DIFF
--- a/ct_footer_debranding/views/ct_footer_debranding.xml
+++ b/ct_footer_debranding/views/ct_footer_debranding.xml
@@ -2,7 +2,7 @@
 <data>
   <!-- inheriting footer view -->
   <template id="ct_footer_debranding" inherit_id="website.brand_promotion" name="Footer debranding" active="True" priority="99">
-    <xpath expr="//div[@class='o_brand_promotion']" position="replace">
+    <xpath expr="//div[hasclass('o_brand_promotion')]" position="replace">
       <div class="o_brand_promotion"></div>
     </xpath>
   </template>


### PR DESCRIPTION
Removes warning: 
WARNING [odoo_instance] odoo.addons.base.models.ir_ui_view: Error-prone use of @class in view Footer debranding (): use the hasclass(*classes) function to filter elements by their classes

This is also compatible with Odoo 16.0 from what I can tell. 